### PR TITLE
Add Support for New EVM Opcodes and Rename SHA3 to KECCAK256

### DIFF
--- a/evmdasm/registry.py
+++ b/evmdasm/registry.py
@@ -36,8 +36,8 @@ INSTRUCTIONS = [
     Instruction(opcode=0x1c, name='SHR', category="bitwise-logic", gas=3, fork="constantinople", description="<TBD> Shift Right", args=[T.Index64('shift'), T.Value('value')], returns=[T.Value('result')]),
     Instruction(opcode=0x1d, name='SAR', category="bitwise-logic", gas=3, fork="constantinople", description="<TBD> Shift arithmetic right", args=[T.Index64('shift'), T.Value('value')], returns=[T.Bool('flag')]),
 
-    # SHA3
-    Instruction(opcode=0x20, name='SHA3', category="cryptographic", gas=30, description="Compute Keccak-256 hash.", args=[T.MemOffset('offset'), T.Length('size')], returns=[T.Value('sha3')]),
+    # KECCAK
+    Instruction(opcode=0x20, name='KECCAK256', category="cryptographic", gas=30, description="Compute Keccak-256 hash.", args=[T.MemOffset('offset'), T.Length('size')], returns=[T.Value('sha3')]),
 
     # Environmental Information
     Instruction(opcode=0x30, name='ADDRESS', category="envinfo", gas=2, description="Get address of currently executing account.", returns=[T.Address('this.address')]),

--- a/evmdasm/registry.py
+++ b/evmdasm/registry.py
@@ -90,6 +90,7 @@ INSTRUCTIONS = [
     Instruction(opcode=0x5e, name='MCOPY', category="memory", gas=3, description="Copy memory areas.", args=[T.MemOffset("offset"), T.MemOffset("offset"), T.Length("length")]),
 
     # Stack Push Operations
+    Instruction(opcode=0x5f, name='PUSH0', category="stack", gas=2, description="Place value 0 on stack.", returns=[T.Value("item")]),
     Instruction(opcode=0x60, name='PUSH1', category="stack", gas=3, length_of_operand=0x1, description="Place 1 byte item on stack.", returns=[T.Value("item")]),
     Instruction(opcode=0x61, name='PUSH2', category="stack", gas=3, length_of_operand=0x2, description="Place 2-byte item on stack.", returns=[T.Value("item")]),
     Instruction(opcode=0x62, name='PUSH3', category="stack",  gas=3, length_of_operand=0x3, description="Place 3-byte item on stack.", returns=[T.Value("item")]),

--- a/evmdasm/registry.py
+++ b/evmdasm/registry.py
@@ -86,6 +86,7 @@ INSTRUCTIONS = [
     Instruction(opcode=0x5a, name='GAS', category="info", gas=2, description="Get the amount of available gas, including the corresponding reduction", returns=[T.Gas("gasleft")]),
     Instruction(opcode=0x5b, name='JUMPDEST', category="label", gas=1, description="Mark a valid destination for jumps."),
     Instruction(opcode=0x5c, name='TLOAD', category="label", gas=100, description="Load word from transient storage.", args=[T.MemOffset("loc")], returns=[T.Word("value")]),
+    Instruction(opcode=0x5d, name='TSTORE', category="label", gas=100, description="Save word to transient storage.", args=[T.MemOffset("loc"), T.Word("value")]),
 
     # Stack Push Operations
     Instruction(opcode=0x60, name='PUSH1', category="stack", gas=3, length_of_operand=0x1, description="Place 1 byte item on stack.", returns=[T.Value("item")]),

--- a/evmdasm/registry.py
+++ b/evmdasm/registry.py
@@ -85,6 +85,7 @@ INSTRUCTIONS = [
     Instruction(opcode=0x59, name='MSIZE', category="memory", gas=2, description="Get the size of active memory in bytes.", returns=[T.Length("memory.length")]),
     Instruction(opcode=0x5a, name='GAS', category="info", gas=2, description="Get the amount of available gas, including the corresponding reduction", returns=[T.Gas("gasleft")]),
     Instruction(opcode=0x5b, name='JUMPDEST', category="label", gas=1, description="Mark a valid destination for jumps."),
+    Instruction(opcode=0x5c, name='TLOAD', category="label", gas=100, description="Load word from transient storage.", args=[T.MemOffset("loc")], returns=[T.Word("value")]),
 
     # Stack Push Operations
     Instruction(opcode=0x60, name='PUSH1', category="stack", gas=3, length_of_operand=0x1, description="Place 1 byte item on stack.", returns=[T.Value("item")]),

--- a/evmdasm/registry.py
+++ b/evmdasm/registry.py
@@ -72,6 +72,7 @@ INSTRUCTIONS = [
 
     
     Instruction(opcode=0x49, name='BLOBHASH', category="blockinfo", gas=3, description="Get versioned hashes.", args=[T.Index256("index")], returns=["block.blobVersionedHashesAtIndex"]),
+    Instruction(opcode=0x4a, name='BLOBBASEFEE', category="blockinfo", gas=2, description="Returns the value of the blob base-fee of the current block.", returns=[T.Gas("block.blobBaseFee")]),
 
     # Stack, Memory, Storage and Flow Operations
     Instruction(opcode=0x50, name='POP', category="stack", gas=2, description="Remove item from stack.", args=[T.Internal("#dummy")], ),

--- a/evmdasm/registry.py
+++ b/evmdasm/registry.py
@@ -87,6 +87,7 @@ INSTRUCTIONS = [
     Instruction(opcode=0x5b, name='JUMPDEST', category="label", gas=1, description="Mark a valid destination for jumps."),
     Instruction(opcode=0x5c, name='TLOAD', category="label", gas=100, description="Load word from transient storage.", args=[T.MemOffset("loc")], returns=[T.Word("value")]),
     Instruction(opcode=0x5d, name='TSTORE', category="label", gas=100, description="Save word to transient storage.", args=[T.MemOffset("loc"), T.Word("value")]),
+    Instruction(opcode=0x5e, name='MCOPY', category="memory", gas=3, description="Copy memory areas.", args=[T.MemOffset("offset"), T.MemOffset("offset"), T.Length("length")]),
 
     # Stack Push Operations
     Instruction(opcode=0x60, name='PUSH1', category="stack", gas=3, length_of_operand=0x1, description="Place 1 byte item on stack.", returns=[T.Value("item")]),

--- a/evmdasm/registry.py
+++ b/evmdasm/registry.py
@@ -70,6 +70,8 @@ INSTRUCTIONS = [
     Instruction(opcode=0x47, name='SELFBALANCE', category="blockinfo", gas=5, description="Get own balance.", returns=[T.Gas("address(this).balance")]),
     Instruction(opcode=0x48, name='BASEFEE', category="blockinfo", gas=2, description="Get the value of the base fee of the current block.", returns=[T.Gas("block.basefee")]),
 
+    
+    Instruction(opcode=0x49, name='BLOBHASH', category="blockinfo", gas=3, description="Get versioned hashes.", args=[T.Index256("index")], returns=["block.blobVersionedHashesAtIndex"]),
 
     # Stack, Memory, Storage and Flow Operations
     Instruction(opcode=0x50, name='POP', category="stack", gas=2, description="Remove item from stack.", args=[T.Internal("#dummy")], ),

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 
-version = "0.1.10"
+version = "0.1.11"
 name = "evmdasm"
 
 setup(


### PR DESCRIPTION
This pull request includes updates to the `evmdasm` library, focusing on opcode definitions and versioning. The most significant changes involve renaming an existing opcode, adding new opcodes, and incrementing the library version.

### Opcode Updates:
* Renamed the opcode `SHA3` to `KECCAK256` for clarity and consistency with cryptographic standards. (`evmdasm/registry.py`, [evmdasm/registry.pyL39-R40](diffhunk://#diff-a90b405adb036b7c6f61b641f62c2decd07a384c83e4ab56fba18f58c38d3071L39-R40))
* Added new opcodes: `TLOAD`, `TSTORE`, `MCOPY`, and `PUSH0`, expanding support for transient storage operations, memory copying, and stack manipulation. (`evmdasm/registry.py`, [evmdasm/registry.pyR88-R93](diffhunk://#diff-a90b405adb036b7c6f61b641f62c2decd07a384c83e4ab56fba18f58c38d3071R88-R93))

### Versioning:
* Incremented the library version from `0.1.10` to `0.1.11` to reflect the new changes. (`setup.py`, [setup.pyL12-R12](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L12-R12))